### PR TITLE
Fix Windows CI: trailing space after backslash caused exit code 127

### DIFF
--- a/.github/actions/install-cpp-dependencies/action.yml
+++ b/.github/actions/install-cpp-dependencies/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         conda install -y cmake ninja liblapacke openblas catch2
 
-    - name: Install MinGW-w64 (Windows only)
+    - name: Install compilers (Windows only)
       if: runner.os == 'Windows'
       shell: bash -el {0}
       run: |
@@ -55,7 +55,7 @@ runs:
           echo "lapacke.h not found"
           exit 1
         fi
-        if [ -d "$UNIX_PREFIX/Library/include/catch2" ] || [ -d "$UNIX_PREFIX/lib/cmake/Catch2" ]; then
+        if [ -d "$UNIX_PREFIX/Library/include/catch2" ] || [ -d "$UNIX_PREFIX/Library/lib/cmake/Catch2" ] || [ -d "$UNIX_PREFIX/lib/cmake/Catch2" ]; then
           echo "Catch2 found"
         else
           echo "Catch2 not found"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,11 +45,12 @@ jobs:
                 -G Ninja \
                 -DCMAKE_C_COMPILER=clang \
                 -DCMAKE_CXX_COMPILER=clang++ \
-                -DCMAKE_DISABLE_FIND_PACKAGE_clang-tidy=TRUE \ 
-                -DCMAKE_DISABLE_FIND_PACKAGE_cppcheck=TRUE \
+                -Dqugar_DEVELOPER_MODE=OFF \
+                -Dqugar_ENABLE_CLANG_TIDY=OFF \
+                -Dqugar_ENABLE_CPPCHECK=OFF \
                 -DBUILD_TESTING=ON \
                 -DCMAKE_PREFIX_PATH="$UNIX_PREFIX;$UNIX_PREFIX/Library" \
-                -DLAPACKE_DIR="$UNIX_PREFIX/Library/include/openblas;$UNIX_PREFIX/Library" \
+                -DLAPACKE_DIR="$UNIX_PREFIX/Library" \
                 -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install"
           cmake --build build --parallel
           cmake --install build
@@ -88,6 +89,7 @@ jobs:
 
 
   build-test-wheel:
+    if: ${{ !contains(inputs.os, 'windows') }}
     runs-on: ${{ inputs.os }}
     defaults:
       run:

--- a/.github/workflows/cross_os_ci.yml
+++ b/.github/workflows/cross_os_ci.yml
@@ -9,15 +9,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  # linux:
-  #   uses: ./.github/workflows/build_and_test.yml
-  #   with:
-  #     os: ubuntu-latest
-  #
-  # macos:
-  #   uses: ./.github/workflows/build_and_test.yml
-  #   with:
-  #     os: macos-latest
+  linux:
+    uses: ./.github/workflows/build_and_test.yml
+    with:
+      os: ubuntu-latest
+
+  macos:
+    uses: ./.github/workflows/build_and_test.yml
+    with:
+      os: macos-latest
 
   windows:
     uses: ./.github/workflows/build_and_test.yml

--- a/cmake/lapacke.cmake
+++ b/cmake/lapacke.cmake
@@ -1,26 +1,32 @@
 macro(qugar_find_lapacke)
   set(LAPACKE_VERSION 3.9)
-  
+
+  # On Windows, conda-forge installs under $CONDA_PREFIX/Library/
+  set(_LAPACKE_SEARCH_PATHS ${LAPACKE_DIR} $ENV{CONDA_PREFIX})
+  if(WIN32 AND DEFINED ENV{CONDA_PREFIX})
+    list(APPEND _LAPACKE_SEARCH_PATHS "$ENV{CONDA_PREFIX}/Library")
+  endif()
+
   # Find LAPACKE header
   find_path(LAPACKE_INCLUDE_DIR
     NAMES lapacke.h
-    PATHS ${LAPACKE_DIR} $ENV{CONDA_PREFIX}
-    PATH_SUFFIXES include
+    PATHS ${_LAPACKE_SEARCH_PATHS}
+    PATH_SUFFIXES include include/openblas
     NO_DEFAULT_PATH
   )
-  
+
   # Find LAPACKE library
   find_library(LAPACKE_LIBRARY
     NAMES lapacke
-    PATHS ${LAPACKE_DIR} $ENV{CONDA_PREFIX}
+    PATHS ${_LAPACKE_SEARCH_PATHS}
     PATH_SUFFIXES lib lib64
     NO_DEFAULT_PATH
   )
-  
+
   # Also find LAPACK library (LAPACKE depends on it)
   find_library(LAPACK_LIBRARY
     NAMES lapack
-    PATHS ${LAPACKE_DIR} $ENV{CONDA_PREFIX}
+    PATHS ${_LAPACKE_SEARCH_PATHS}
     PATH_SUFFIXES lib lib64
     NO_DEFAULT_PATH
   )


### PR DESCRIPTION
## Summary
- **Root cause fix**: Removed trailing space after `\` on line 48 of `build_and_test.yml` that broke bash line continuation, causing `-DCMAKE_DISABLE_FIND_PACKAGE_cppcheck=TRUE` to be interpreted as a command (exit code 127)
- Replaced ineffective `CMAKE_DISABLE_FIND_PACKAGE_*` flags with correct project options (`qugar_ENABLE_CLANG_TIDY=OFF`, `qugar_ENABLE_CPPCHECK=OFF`, `qugar_DEVELOPER_MODE=OFF`)
- Fixed LAPACKE discovery for Windows conda-forge paths (`$CONDA_PREFIX/Library/`)
- Skipped Python wheel job on Windows (fenics-dolfinx unavailable)
- Re-enabled Linux and macOS CI jobs

## Test plan
- [ ] Windows `build-and-test` job passes (cmake configures, builds, installs)
- [ ] Windows `build-test-wheel` job is skipped
- [ ] Linux and macOS jobs pass without regressions
- [ ] LAPACKE found on Windows (check CMake output for `LAPACKE found:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)